### PR TITLE
Se eliminan efecto hover de los componentes brands y techstack

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": ["next/babel","next/core-web-vitals"]
 }

--- a/components/Brands/SingleBrand.tsx
+++ b/components/Brands/SingleBrand.tsx
@@ -9,7 +9,7 @@ const SingleBrand = ({ brand }: { brand: Brand }) => {
         href={href}
         target="_blank"
         rel="nofollow noreferrer"
-        className="relative h-10 w-full opacity-70 grayscale transition hover:opacity-100 hover:grayscale-0 dark:opacity-60 dark:hover:opacity-100"
+        className="relative h-10 w-full transition opacity-100 dark:hover:opacity-100"
       >
         <Image src={image} alt={name} fill />
       </a>

--- a/components/Brands/index.tsx
+++ b/components/Brands/index.tsx
@@ -8,7 +8,7 @@ const Brands = () => {
       <div className="container">
         <div className="-mx-4 flex flex-wrap">
           <div className="w-full px-4">
-            <SectionTitle title="Trust By" paragraph="" center mb="80px" />
+            <SectionTitle title="Trust By" paragraph="Trusted by world-class companies. Excellence and innovation at the core of everything we do." center mb="80px" />
             <div
               className="wow fadeInUp flex flex-wrap items-center justify-center rounded-md bg-dark px-8 py-8 dark:bg-primary dark:bg-opacity-5 sm:px-10 md:px-[50px] md:py-[60px] xl:p-[50px] 2xl:px-[70px] 2xl:py-[60px]"
               data-wow-delay=".1s

--- a/components/TechStack/SingleTechStack.tsx
+++ b/components/TechStack/SingleTechStack.tsx
@@ -1,25 +1,19 @@
 import Image from "next/image";
 import { TechStackType } from "@/types/techstack";
 
-
 const SingleTechStack = ({ techstack }: { techstack: TechStackType }) => {
-    const { image, name } = techstack;
-  
-    return (
-  
-      <div className="mx-3 flex w-full max-w-[160px] items-center justify-center py-[15px] sm:mx-4 lg:max-w-[130px] xl:mx-6 xl:max-w-[150px] 2xl:mx-8 2xl:max-w-[160px]">
-        <a      
-          target="_blank"
-          rel="nofollow noreferrer"
-          className="relative h-10 w-full transition opacity-100 dark:hover:opacity-100"
-        >
-          <Image src={image} alt={name} fill />
-        </a>
-  
-  
-      </div>
-    
-    );
-  };
+  const { image, name } = techstack;
 
+  return (
+    <div className="mx-3 flex w-full max-w-[160px] items-center justify-center py-[15px] sm:mx-4 lg:max-w-[130px] xl:mx-6 xl:max-w-[150px] 2xl:mx-8 2xl:max-w-[160px]">
+      <a
+        target="_blank"
+        rel="nofollow noreferrer"
+        className="relative h-10 w-full opacity-100 transition dark:hover:opacity-100"
+      >
+        <Image src={image} alt={name} fill />
+      </a>
+    </div>
+  );
+};
 export default SingleTechStack;

--- a/components/TechStack/SingleTechStack.tsx
+++ b/components/TechStack/SingleTechStack.tsx
@@ -11,7 +11,7 @@ const SingleTechStack = ({ techstack }: { techstack: TechStackType }) => {
         <a      
           target="_blank"
           rel="nofollow noreferrer"
-          className="relative h-10 w-full opacity-70 grayscale transition hover:opacity-100 hover:grayscale-0 dark:opacity-60 dark:hover:opacity-100"
+          className="relative h-10 w-full transition opacity-100 dark:hover:opacity-100"
         >
           <Image src={image} alt={name} fill />
         </a>


### PR DESCRIPTION
# Description

Se elimina la clase dark:opacity-60 de la etiqueta <a>: quedando className="relative h-10 w-full transition opacity-100 dark:hover:opacity-100" lo que permite visualizar la imagen del color original 


[To obtain the URL, navigate to the ticket on Trello and click on the "Share" button located at the bottom right corner.
Paste between the parentheses: [Trello Ticket URL]()
](https://trello.com/c/p0WVILGg/22-update-title-size-of-trust-by)

![image](https://user-images.githubusercontent.com/33616594/234401486-37c3d3c1-e71b-456b-9ebb-f1a3c63e729c.png)

se aplica un cambio importante para evitar un error 

![image](https://user-images.githubusercontent.com/33616594/234402009-c9e7efa6-c7ae-4058-8f0d-eedc74fb2b65.png)


# Checklist
Please ensure that you have completed the following tasks:

- [x ] I have performed a self-review of my own code
- [x ] I have run ``` npm run lint ``` to automatically fix any linting issues
- [x ] I have resolved all linting issues within the files modified in this PR
- [x ] I have provided visual evidence of the changes (e.g., screenshots, GIFs, or videos)
- [x ] I have added comments to my code, particularly in difficult-to-understand areas
- [ ] I have made corresponding updates to the documentation, if necessary
- [ x] My changes generate no new warnings in the terminal or browser console

# Visual Evidence
Please include any relevant screenshots, GIFs, or videos demonstrating the changes made in this pull request.

# Test Coverage (Optional)
If applicable, please attach screenshots of the test coverage report:

Run npm run ``` test:coverage:changed ``` to generate the report
Note: Including test coverage is optional for now, but highly encouraged. (This is a task we will implement soon).
